### PR TITLE
Link notification to releases page

### DIFF
--- a/src/background/main.js
+++ b/src/background/main.js
@@ -30,7 +30,7 @@ if (process.env.DEBUG_MODE) {
 browser.notifications.onClicked.addListener(name => {
   if (/^[^/\s]+\/[^/\s]+$/.test(name)) {
     // is a repo
-    browser.tabs.create({ url: 'https://github.com/' + name })
+    browser.tabs.create({ url: 'https://github.com/' + name + '/releases' })
     browser.notifications.clear(name)
     clearBadge()
   }


### PR DESCRIPTION
Redirect browser notifcation to repos release instead of repository page.

Close: #4 